### PR TITLE
Fixed bug with GenericTraderProxyBase

### DIFF
--- a/contracts/external/helpers/GenericTraderProxyBase.sol
+++ b/contracts/external/helpers/GenericTraderProxyBase.sol
@@ -355,13 +355,12 @@ contract GenericTraderProxyBase is IGenericTraderProxyBase {
         GenericTraderProxyCache memory _cache,
         uint256[] memory _marketIdsPath,
         uint256[] memory _amountWeisPath,
-        TraderParam[] memory _tradersPath,
-        uint256 _traderActionsLength
+        TraderParam[] memory _tradersPath
     )
         internal
         view
     {
-        for (uint256 i = 0; i < _traderActionsLength; i++) {
+        for (uint256 i = 0; i < _tradersPath.length; i++) {
             if (_tradersPath[i].traderType == TraderType.ExternalLiquidity) {
                 _actions[_cache.actionsCursor++] = AccountActionLib.encodeExternalSellAction(
                     TRADE_ACCOUNT_INDEX,

--- a/contracts/external/helpers/LiquidatorAssetRegistry.sol
+++ b/contracts/external/helpers/LiquidatorAssetRegistry.sol
@@ -44,8 +44,6 @@ contract LiquidatorAssetRegistry is ILiquidatorAssetRegistry, OnlyDolomiteMargin
     // ============ Storage ============
 
     mapping(uint256 => OpenZeppelinEnumerableSet.AddressSet) private _marketIdToLiquidatorWhitelistMap;
-    mapping(uint256 => OpenZeppelinEnumerableSet.AddressSet) private _marketIdToUnwrapperMap;
-    mapping(uint256 => OpenZeppelinEnumerableSet.AddressSet) private _marketIdToWrapperMap;
 
     // ============ Constructor ============
 

--- a/contracts/external/interfaces/IIsolationModeWrapperTrader.sol
+++ b/contracts/external/interfaces/IIsolationModeWrapperTrader.sol
@@ -33,7 +33,7 @@ import { IExchangeWrapper } from "../../protocol/interfaces/IExchangeWrapper.sol
 contract IIsolationModeWrapperTrader is IExchangeWrapper {
 
     /**
-     * @return The liquidity token that this contract can wrap
+     * @return The isolation mode token that this contract can wrap (the output token)
      */
     function token() external view returns (address);
 
@@ -43,8 +43,7 @@ contract IIsolationModeWrapperTrader is IExchangeWrapper {
     function isValidInputToken(address _inputToken) external view returns (bool);
 
     /**
-     * @return  The number of Actions used to wrap the LP token into `outputMarketId`. If `owedMarketId` equals
-     *          `outputMarketId`, there is no need to chain additional actions on, since the debt will be paid off.
+     * @return  The number of Actions used to wrap a valid input token into the this wrapper's Isolation Mode token.
      */
     function actionsLength() external pure returns (uint256);
 

--- a/contracts/external/proxies/GenericTraderProxyV1.sol
+++ b/contracts/external/proxies/GenericTraderProxyV1.sol
@@ -120,16 +120,14 @@ contract GenericTraderProxyV1 is IGenericTraderProxyV1, GenericTraderProxyBase, 
             _tradeAccountNumber
         );
 
-        uint256 traderActionsLength = _getActionsLengthForTraderParams(_tradersPath);
-        Actions.ActionArgs[] memory actions = new Actions.ActionArgs[](traderActionsLength);
+        Actions.ActionArgs[] memory actions = new Actions.ActionArgs[](_getActionsLengthForTraderParams(_tradersPath));
         _appendTraderActions(
             accounts,
             actions,
             cache,
             _marketIdsPath,
             _amountWeisPath,
-            _tradersPath,
-            traderActionsLength
+            _tradersPath
         );
 
         cache.dolomiteMargin.operate(accounts, actions);
@@ -183,10 +181,11 @@ contract GenericTraderProxyV1 is IGenericTraderProxyV1, GenericTraderProxyBase, 
             number: cache.otherAccountNumber
         });
 
-        uint256 traderActionsLength = _getActionsLengthForTraderParams(_tradersPath);
         uint256 transferActionsLength = _getActionsLengthForTransferCollateralParam(_transferCollateralParams);
         Actions.ActionArgs[] memory actions = new Actions.ActionArgs[](
-            traderActionsLength + transferActionsLength + _getActionsLengthForExpiryParam(_expiryParams)
+            _getActionsLengthForTraderParams(_tradersPath)
+                + transferActionsLength
+                + _getActionsLengthForExpiryParam(_expiryParams)
         );
         _appendTraderActions(
             accounts,
@@ -194,8 +193,7 @@ contract GenericTraderProxyV1 is IGenericTraderProxyV1, GenericTraderProxyBase, 
             cache,
             _marketIdsPath,
             _amountWeisPath,
-            _tradersPath,
-            traderActionsLength
+            _tradersPath
         );
         _appendTransferActions(
             actions,

--- a/contracts/external/proxies/LiquidatorProxyV1.sol
+++ b/contracts/external/proxies/LiquidatorProxyV1.sol
@@ -102,7 +102,8 @@ contract LiquidatorProxyV1 is OnlyDolomiteMargin, ReentrancyGuard, LiquidatorPro
      *
      * @param _solidAccount         The account that will do the liquidating
      * @param _liquidAccount        The account that will be liquidated
-     * @param _minLiquidatorRatio   The minimum collateralization ratio to leave the solidAccount at
+     * @param _minLiquidatorRatio   The minimum collateralization ratio to leave the solidAccount at. Setting this value
+     *                              to `150000000000000000` is analogous to a 115% collateralization ratio.
      * @param _owedPreferences      Ordered list of markets to repay first
      * @param _heldPreferences      Ordered list of markets to receive payout for first
      */

--- a/contracts/external/proxies/LiquidatorProxyV4WithGenericTrader.sol
+++ b/contracts/external/proxies/LiquidatorProxyV4WithGenericTrader.sol
@@ -161,9 +161,8 @@ contract LiquidatorProxyV4WithGenericTrader is
         // `traderAccountCursor` index
         accounts[1] = _liquidAccount;
 
-        uint256 traderActionsLength = _getActionsLengthForTraderParams(_tradersPath);
         Actions.ActionArgs[] memory actions = new Actions.ActionArgs[](
-            /* liquidationActionsLength = */ 1 + traderActionsLength
+            /* liquidationActionsLength = */ 1 + _getActionsLengthForTraderParams(_tradersPath)
         );
         _appendLiquidationAction(
             actions,
@@ -177,8 +176,7 @@ contract LiquidatorProxyV4WithGenericTrader is
             genericCache,
             _marketIdsPath,
             _amountWeisPath,
-            _tradersPath,
-            traderActionsLength
+            _tradersPath
         );
 
         genericCache.dolomiteMargin.operate(accounts, actions);

--- a/contracts/testing/TestIsolationModeUnwrapperTrader.sol
+++ b/contracts/testing/TestIsolationModeUnwrapperTrader.sol
@@ -19,24 +19,27 @@
 pragma solidity ^0.5.7;
 pragma experimental ABIEncoderV2;
 
-import { IIsolationModeUnwrapperTrader } from "../external/interfaces/IIsolationModeUnwrapperTrader.sol";
+import {IIsolationModeUnwrapperTrader} from "../external/interfaces/IIsolationModeUnwrapperTrader.sol";
 
-import { AccountActionLib } from "../external/lib/AccountActionLib.sol";
+import {AccountActionLib} from "../external/lib/AccountActionLib.sol";
 
-import { Actions } from "../protocol/lib/Actions.sol";
-import { DolomiteMarginMath } from "../protocol/lib/DolomiteMarginMath.sol";
-import { Require } from "../protocol/lib/Require.sol";
+import {ICallee} from "../protocol/interfaces/ICallee.sol";
 
-import { IDolomiteMargin } from "../protocol/interfaces/IDolomiteMargin.sol";
+import {Account} from "../protocol/lib/Account.sol";
+import {Actions} from "../protocol/lib/Actions.sol";
+import {DolomiteMarginMath} from "../protocol/lib/DolomiteMarginMath.sol";
+import {Require} from "../protocol/lib/Require.sol";
 
-import { TestToken } from "./TestToken.sol";
+import {IDolomiteMargin} from "../protocol/interfaces/IDolomiteMargin.sol";
+
+import {TestToken} from "./TestToken.sol";
 
 
-contract TestIsolationModeUnwrapperTrader is IIsolationModeUnwrapperTrader {
+contract TestIsolationModeUnwrapperTrader is IIsolationModeUnwrapperTrader, ICallee {
 
     bytes32 private constant FILE = "TestIsolationModeUnwrapperTrader";
 
-    uint256 constant public ACTIONS_LENGTH = 1;
+    uint256 constant public ACTIONS_LENGTH = 2;
 
     IDolomiteMargin public DOLOMITE_MARGIN;
     address public UNDERLYING_TOKEN;
@@ -52,6 +55,29 @@ contract TestIsolationModeUnwrapperTrader is IIsolationModeUnwrapperTrader {
         DOLOMITE_MARGIN = IDolomiteMargin(_dolomiteMargin);
     }
 
+    function exchange(
+        address,
+        address _receiver,
+        address _makerToken,
+        address _takerToken,
+        uint256,
+        bytes calldata _orderData
+    )
+    external
+    returns (uint256) {
+        Require.that(
+            _takerToken == UNDERLYING_TOKEN,
+            FILE,
+            "Taker token must be UNDERLYING",
+            _takerToken
+        );
+
+        (uint256 amountOut,) = abi.decode(_orderData, (uint256, bytes));
+        TestToken(_makerToken).setBalance(address(this), amountOut);
+        TestToken(_makerToken).approve(_receiver, amountOut);
+        return amountOut;
+    }
+
     function token() external view returns (address) {
         return UNDERLYING_TOKEN;
     }
@@ -62,10 +88,6 @@ contract TestIsolationModeUnwrapperTrader is IIsolationModeUnwrapperTrader {
 
     function isValidOutputToken(address _outputToken) external view returns (bool) {
         return _outputToken == OUTPUT_TOKEN;
-    }
-
-    function actionsLength() external pure returns (uint256) {
-        return ACTIONS_LENGTH;
     }
 
     function createActionsForUnwrapping(
@@ -114,30 +136,13 @@ contract TestIsolationModeUnwrapperTrader is IIsolationModeUnwrapperTrader {
             amountOut,
             _orderData
         );
-        return actions;
-    }
-
-    function exchange(
-        address,
-        address _receiver,
-        address _makerToken,
-        address _takerToken,
-        uint256,
-        bytes calldata _orderData
-    )
-    external
-    returns (uint256) {
-        Require.that(
-            _takerToken == UNDERLYING_TOKEN,
-            FILE,
-            "Taker token must be UNDERLYING",
-            _takerToken
+        // Unwrappers can have length > 1 so we encode a no-op to simulate there being more than one actions
+        actions[1] = AccountActionLib.encodeCallAction(
+            _primaryAccountId,
+            address(this),
+            bytes("")
         );
-
-        (uint256 amountOut,) = abi.decode(_orderData, (uint256, bytes));
-        TestToken(_makerToken).setBalance(address(this), amountOut);
-        TestToken(_makerToken).approve(_receiver, amountOut);
-        return amountOut;
+        return actions;
     }
 
     function getExchangeCost(
@@ -163,5 +168,30 @@ contract TestIsolationModeUnwrapperTrader is IIsolationModeUnwrapperTrader {
         uint256 takerPrice = DOLOMITE_MARGIN.getMarketPrice(takerMarketId).value;
 
         return DolomiteMarginMath.getPartial(_desiredMakerToken, makerPrice, takerPrice);
+    }
+
+    function actionsLength() external pure returns (uint256) {
+        return ACTIONS_LENGTH;
+    }
+
+    // ========================= Public Functions =========================
+
+    function callFunction(
+        address sender,
+        Account.Info memory accountInfo,
+        bytes memory data
+    )
+    public {
+        Require.that(
+            msg.sender == address(DOLOMITE_MARGIN),
+            FILE,
+            "Invalid caller",
+            msg.sender
+        );
+        Require.that(
+            data.length == 0,
+            FILE,
+            "callFunction should be noop"
+        );
     }
 }

--- a/contracts_coverage/external/helpers/GenericTraderProxyBase.sol
+++ b/contracts_coverage/external/helpers/GenericTraderProxyBase.sol
@@ -355,13 +355,12 @@ contract GenericTraderProxyBase is IGenericTraderProxyBase {
         GenericTraderProxyCache memory _cache,
         uint256[] memory _marketIdsPath,
         uint256[] memory _amountWeisPath,
-        TraderParam[] memory _tradersPath,
-        uint256 _traderActionsLength
+        TraderParam[] memory _tradersPath
     )
         internal
         view
     {
-        for (uint256 i = 0; i < _traderActionsLength; i++) {
+        for (uint256 i = 0; i < _tradersPath.length; i++) {
             if (_tradersPath[i].traderType == TraderType.ExternalLiquidity) {
                 _actions[_cache.actionsCursor++] = AccountActionLib.encodeExternalSellAction(
                     TRADE_ACCOUNT_INDEX,

--- a/contracts_coverage/external/helpers/LiquidatorAssetRegistry.sol
+++ b/contracts_coverage/external/helpers/LiquidatorAssetRegistry.sol
@@ -44,8 +44,6 @@ contract LiquidatorAssetRegistry is ILiquidatorAssetRegistry, OnlyDolomiteMargin
     // ============ Storage ============
 
     mapping(uint256 => OpenZeppelinEnumerableSet.AddressSet) private _marketIdToLiquidatorWhitelistMap;
-    mapping(uint256 => OpenZeppelinEnumerableSet.AddressSet) private _marketIdToUnwrapperMap;
-    mapping(uint256 => OpenZeppelinEnumerableSet.AddressSet) private _marketIdToWrapperMap;
 
     // ============ Constructor ============
 

--- a/contracts_coverage/external/interfaces/IIsolationModeWrapperTrader.sol
+++ b/contracts_coverage/external/interfaces/IIsolationModeWrapperTrader.sol
@@ -33,7 +33,7 @@ import { IExchangeWrapper } from "../../protocol/interfaces/IExchangeWrapper.sol
 contract IIsolationModeWrapperTrader is IExchangeWrapper {
 
     /**
-     * @return The liquidity token that this contract can wrap
+     * @return The isolation mode token that this contract can wrap (the output token)
      */
     function token() external view returns (address);
 
@@ -43,8 +43,7 @@ contract IIsolationModeWrapperTrader is IExchangeWrapper {
     function isValidInputToken(address _inputToken) external view returns (bool);
 
     /**
-     * @return  The number of Actions used to wrap the LP token into `outputMarketId`. If `owedMarketId` equals
-     *          `outputMarketId`, there is no need to chain additional actions on, since the debt will be paid off.
+     * @return  The number of Actions used to wrap a valid input token into the this wrapper's Isolation Mode token.
      */
     function actionsLength() external pure returns (uint256);
 

--- a/contracts_coverage/external/proxies/GenericTraderProxyV1.sol
+++ b/contracts_coverage/external/proxies/GenericTraderProxyV1.sol
@@ -120,16 +120,14 @@ contract GenericTraderProxyV1 is IGenericTraderProxyV1, GenericTraderProxyBase, 
             _tradeAccountNumber
         );
 
-        uint256 traderActionsLength = _getActionsLengthForTraderParams(_tradersPath);
-        Actions.ActionArgs[] memory actions = new Actions.ActionArgs[](traderActionsLength);
+        Actions.ActionArgs[] memory actions = new Actions.ActionArgs[](_getActionsLengthForTraderParams(_tradersPath));
         _appendTraderActions(
             accounts,
             actions,
             cache,
             _marketIdsPath,
             _amountWeisPath,
-            _tradersPath,
-            traderActionsLength
+            _tradersPath
         );
 
         cache.dolomiteMargin.operate(accounts, actions);
@@ -183,10 +181,11 @@ contract GenericTraderProxyV1 is IGenericTraderProxyV1, GenericTraderProxyBase, 
             number: cache.otherAccountNumber
         });
 
-        uint256 traderActionsLength = _getActionsLengthForTraderParams(_tradersPath);
         uint256 transferActionsLength = _getActionsLengthForTransferCollateralParam(_transferCollateralParams);
         Actions.ActionArgs[] memory actions = new Actions.ActionArgs[](
-            traderActionsLength + transferActionsLength + _getActionsLengthForExpiryParam(_expiryParams)
+            _getActionsLengthForTraderParams(_tradersPath)
+                + transferActionsLength
+                + _getActionsLengthForExpiryParam(_expiryParams)
         );
         _appendTraderActions(
             accounts,
@@ -194,8 +193,7 @@ contract GenericTraderProxyV1 is IGenericTraderProxyV1, GenericTraderProxyBase, 
             cache,
             _marketIdsPath,
             _amountWeisPath,
-            _tradersPath,
-            traderActionsLength
+            _tradersPath
         );
         _appendTransferActions(
             actions,

--- a/contracts_coverage/external/proxies/LiquidatorProxyV1.sol
+++ b/contracts_coverage/external/proxies/LiquidatorProxyV1.sol
@@ -102,7 +102,8 @@ contract LiquidatorProxyV1 is OnlyDolomiteMargin, ReentrancyGuard, LiquidatorPro
      *
      * @param _solidAccount         The account that will do the liquidating
      * @param _liquidAccount        The account that will be liquidated
-     * @param _minLiquidatorRatio   The minimum collateralization ratio to leave the solidAccount at
+     * @param _minLiquidatorRatio   The minimum collateralization ratio to leave the solidAccount at. Setting this value
+     *                              to `150000000000000000` is analogous to a 115% collateralization ratio.
      * @param _owedPreferences      Ordered list of markets to repay first
      * @param _heldPreferences      Ordered list of markets to receive payout for first
      */

--- a/contracts_coverage/external/proxies/LiquidatorProxyV4WithGenericTrader.sol
+++ b/contracts_coverage/external/proxies/LiquidatorProxyV4WithGenericTrader.sol
@@ -161,9 +161,8 @@ contract LiquidatorProxyV4WithGenericTrader is
         // `traderAccountCursor` index
         accounts[1] = _liquidAccount;
 
-        uint256 traderActionsLength = _getActionsLengthForTraderParams(_tradersPath);
         Actions.ActionArgs[] memory actions = new Actions.ActionArgs[](
-            /* liquidationActionsLength = */ 1 + traderActionsLength
+            /* liquidationActionsLength = */ 1 + _getActionsLengthForTraderParams(_tradersPath)
         );
         _appendLiquidationAction(
             actions,
@@ -177,8 +176,7 @@ contract LiquidatorProxyV4WithGenericTrader is
             genericCache,
             _marketIdsPath,
             _amountWeisPath,
-            _tradersPath,
-            traderActionsLength
+            _tradersPath
         );
 
         genericCache.dolomiteMargin.operate(accounts, actions);

--- a/migrations/deployed.json
+++ b/migrations/deployed.json
@@ -364,8 +364,8 @@
     "LiquidatorProxyV1": {
         "42161": {
             "links": {},
-            "address": "0x84b027f8fcefe40d044ccf9ccb54cc6e48c53450",
-            "transactionHash": "0x8fdbb4829ee20722e7510502ba6b7a450c3dbe9b623b21eb3e589f71c0f6945c"
+            "address": "0x8c6e337dA1bD534548c5A9b6aC3d9e4D15Fa715A",
+            "transactionHash": "0x25ec230f87adde64b081eaec616428a472b806a1da20aecdf64075b778b97c6e"
         },
         "80001": {
             "links": {},
@@ -783,8 +783,8 @@
     "LiquidatorAssetRegistry": {
         "42161": {
             "links": {},
-            "address": "0x89324260096f1e7D3678Bf0ec9E3b8c7530111b2",
-            "transactionHash": "0x8023408ca5d1408a4d887eb11674da54dcb910affd091e9f0e9a13f04f7a3b53"
+            "address": "0x10d98759762EFaC656BD4bE7F2f5599208F44FAc",
+            "transactionHash": "0xe23f3782e75b1b8bc4efdae28212f7d6012ca53a6c0e0fcdb14aacc38486ba03"
         },
         "421613": {
             "links": {},
@@ -809,6 +809,13 @@
             "links": {},
             "address": "0x2536ef4105a6173683C7fFCE9547091960F6d939",
             "transactionHash": "0xe5d59294ad68866954d5c737aa7bb766783526922e839efc2de7a0d3d71eec15"
+        }
+    },
+    "LiquidatorProxyV4WithGenericTrader": {
+        "42161": {
+            "links": {},
+            "address": "0xfCFCe8d1899F0e4773ca5722592E4aA19FEc79B9",
+            "transactionHash": "0xc21619d99487ddb52472d72dba99b48cd922cfd885165a7f7234f8752615e2d3"
         }
     }
 }

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "deploy_coverage": "npm run replace_bytecode && RPC_NODE_URI=http://127.0.01:8545 npm run reset_test_evm && COVERAGE_REPLICA_DEPLOY=true node --max-old-space-size=16384 node_modules/.bin/truffle migrate --network coverage_replica && RPC_NODE_URI=http://127.0.0.1:8545 npm run snapshot_test_evm && npm run build:contract-artifacts",
     "deploy_test_ci": "RPC_NODE_URI=http://0.0.0.0:8545 npm run reset_test_evm && npm run migrate -- --network test_ci --reset && RPC_NODE_URI=http://0.0.0.0:8545 npm run snapshot_test_evm && npm run check_amm_bytecode && npm run build:contract-artifacts",
     "test_only": "NODE_ENV=test node --max-old-space-size=16384 node_modules/.bin/truffle test --network test",
-    "test_only_specific": "NODE_ENV=test node --max-old-space-size=16384 node_modules/.bin/truffle test --network test test/proxies/LiquidatorProxyV3WithExternalLiquidityToken.test.ts",
+    "test_only_specific": "NODE_ENV=test node --max-old-space-size=16384 node_modules/.bin/truffle test --network test test/proxies/GenericTraderProxyV1.test.ts",
     "ci_test": "NODE_ENV=test RPC_NODE_URI=http://0.0.0.0:8545 truffle test --network test",
     "reset_test_evm": "node scripts/reset-test-evm.js",
     "snapshot_test_evm": "node scripts/snapshot-test-evm.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dolomite-exchange/dolomite-margin",
-  "version": "0.9.19",
+  "version": "0.9.20",
   "description": "Ethereum Smart Contracts and TypeScript library used for the DolomiteMargin trading protocol",
   "engines": {
     "npm": "6.14.x"

--- a/scripts/DeployContract.ts
+++ b/scripts/DeployContract.ts
@@ -1,11 +1,11 @@
-import { abi, bytecode, contractName } from '../build/contracts/LiquidatorProxyV1WithAmm.json';
+import { abi, bytecode, contractName } from '../build/contracts/LiquidatorProxyV4WithGenericTrader.json';
 import { ConfirmationType, DolomiteMargin } from '../src';
-import { LiquidatorProxyV1WithAmm } from '../build/wrappers/LiquidatorProxyV1WithAmm';
+import { LiquidatorProxyV4WithGenericTrader } from '../build/wrappers/LiquidatorProxyV4WithGenericTrader';
 import { execSync } from 'child_process';
 import deployed from '../migrations/deployed.json';
 import { promisify } from 'es6-promisify';
 import fs from 'fs';
-const truffle = require('../truffle');
+const truffle = require('../truffle.js');
 const writeFileAsync = promisify(fs.writeFile);
 
 async function sleep(ms: number): Promise<void> {
@@ -27,18 +27,17 @@ async function deploy(): Promise<void> {
   const provider = truffle.networks[network].provider();
   const dolomiteMargin = new DolomiteMargin(provider, networkId);
   const deployer = (await dolomiteMargin.web3.eth.getAccounts())[0];
-  const contract = new dolomiteMargin.web3.eth.Contract(abi) as LiquidatorProxyV1WithAmm;
+  const contract = new dolomiteMargin.web3.eth.Contract(abi) as LiquidatorProxyV4WithGenericTrader;
   const txResult = await dolomiteMargin.contracts.callContractFunction(
     contract.deploy({
       data: bytecode,
       arguments: [
-        dolomiteMargin.address,
-        dolomiteMargin.dolomiteAmmRouterProxy.address,
         dolomiteMargin.expiry.address,
+        dolomiteMargin.address,
         dolomiteMargin.liquidatorAssetRegistry.address,
       ],
     }),
-    { confirmationType: ConfirmationType.Confirmed, gas: '30000000', gasPrice: '100000000', from: deployer },
+    { confirmationType: ConfirmationType.Confirmed, gas: '60000000', gasPrice: '100000000', from: deployer },
   );
 
   console.log(`Deployed ${contractName} to ${txResult.contractAddress}`);

--- a/src/lib/interest-constants.json
+++ b/src/lib/interest-constants.json
@@ -83,6 +83,9 @@
     },
     "8": {
       "interestRateModel": "AlwaysZero"
+    },
+    "9": {
+      "interestRateModel": "AlwaysZero"
     }
   },
   "421611": {


### PR DESCRIPTION
The `for` loop in `_appendTraderActions` should have iterated using `_tradersPath.length` instead of `traderActionsLength`.

We uncovered this bug while QA testing and updated our unit tests to catch this as well.